### PR TITLE
fix(benchmark): resolve bundled engine sidecar, not bare PATH lookup

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3224,18 +3224,6 @@ pub struct BenchmarkRunArgs {
     pub council: Option<bool>,
 }
 
-fn resolve_prevail_bin() -> String {
-    // Prefer ~/.local/bin/prevail (the install script's target),
-    // fall back to whatever's first on PATH.
-    if let Ok(home) = std::env::var("HOME") {
-        let local = format!("{home}/.local/bin/prevail");
-        if Path::new(&local).exists() {
-            return local;
-        }
-    }
-    "prevail".to_string()
-}
-
 async fn spawn_prevail_streaming(
     app: tauri::AppHandle,
     session: String,
@@ -3245,7 +3233,12 @@ async fn spawn_prevail_streaming(
     use tokio::io::{AsyncBufReadExt, BufReader};
     use tokio::process::Command as TokioCommand;
 
-    let bin = resolve_prevail_bin();
+    // Use the canonical sidecar-aware resolver (engine::resolve_prevail_bin):
+    // bundled `Contents/MacOS/prevail` first, so a fresh DMG install works
+    // with no separately-installed CLI. The old local duplicate only checked
+    // ~/.local/bin and fell back to a bare PATH lookup, which is why the
+    // benchmark failed with `spawn prevail failed` on a clean install.
+    let bin = engine::resolve_prevail_bin();
     let (combined_path, user, logname) = build_cli_env();
 
     let mut child = TokioCommand::new(&bin)


### PR DESCRIPTION
## Problem

Hitting **Run** on a benchmark in a fresh DMG install fails with:

```
Unhandled rejection:
spawn prevail failed: No such file or directory (os error 2)
```

…even though the engine binary ships right next to the app at `Contents/MacOS/prevail`.

## Root cause

There were **two** `resolve_prevail_bin()` functions that disagreed:

| Resolver | Sidecar-aware? | Used by |
|---|---|---|
| `engine.rs::resolve_prevail_bin` | ✅ checks `current_exe()/../prevail` first | every engine call (e.g. `lib.rs:2147`) |
| `lib.rs::resolve_prevail_bin` (duplicate) | ❌ only `~/.local/bin`, then bare PATH | the native benchmark runner |

On a clean install there's no `~/.local/bin/prevail`, so the benchmark's resolver fell through to a bare `"prevail"` lookup. A Finder-launched app has a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`), so the lookup fails — despite the bundled sidecar being present.

## Fix

Delete the divergent duplicate and call the canonical `engine::resolve_prevail_bin()`, which resolves the bundled sidecar first before any installed-CLI fallbacks. A clean download now benchmarks with zero setup.

- `cargo check` passes (no new warnings).
- 1 file changed, −13/+6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)