### PR TITLE
fix(appmode): pass the seeded vault to engine_appmode_set on demo entry

### DIFF
--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -722,10 +722,22 @@ pub fn engine_appmode_get() -> Result<serde_json::Value, String> {
     run_engine_json(&["appmode", "get"])
 }
 
-/// `prevail appmode set --mode demo|production`.
+/// `prevail appmode set --mode demo|production [--vault <path>]`. The optional
+/// `vault` is forwarded so a first-launch `set --mode demo` (before any engine
+/// config exists) seeds the config pointed at the seeded sandbox rather than the
+/// bundled demo default.
 #[tauri::command]
-pub fn engine_appmode_set(mode: String) -> Result<serde_json::Value, String> {
-    run_engine_json(&["appmode", "set", "--mode", &mode])
+pub fn engine_appmode_set(
+    mode: String,
+    vault: Option<String>,
+) -> Result<serde_json::Value, String> {
+    let mut a: Vec<String> = vec!["appmode".into(), "set".into(), "--mode".into(), mode];
+    if let Some(v) = vault.filter(|s| !s.is_empty()) {
+        a.push("--vault".into());
+        a.push(v);
+    }
+    let refs: Vec<&str> = a.iter().map(|s| s.as_str()).collect();
+    run_engine_json(&refs)
 }
 
 /// `prevail appmode init` — prepare a clean production workspace and switch to

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1886,7 +1886,7 @@ export default function App() {
         // the bundled resources/sample-vault and marks it demo. (F3 auto-demo.)
         const seedDemo = async () => {
           const path = await invoke<string>("import_sample_vault");
-          await invoke("engine_appmode_set", { mode: "demo" }).catch(() => {});
+          await invoke("engine_appmode_set", { mode: "demo", vault: path }).catch(() => {});
           await invoke("engine_appmode_mark_demo", { vault: path }).catch(() => {});
           setVaultPath(path);
           lsSet(LS.vault, path);
@@ -2337,7 +2337,7 @@ export default function App() {
       // Loading the sample vault means you're exploring — mark demo mode so the
       // Settings banner offers the switch to production. (F3) Tag the vault as a
       // demo sandbox so the switch-to-production flow can safely clear it later.
-      await invoke("engine_appmode_set", { mode: "demo" }).catch(() => {});
+      await invoke("engine_appmode_set", { mode: "demo", vault: path }).catch(() => {});
       await invoke("engine_appmode_mark_demo", { vault: path }).catch(() => {});
       setVaultPath(path);
       lsSet(LS.vault, path);


### PR DESCRIPTION
## What

The first-launch demo flow seeds the sample vault, then calls `engine_appmode_set("demo")` — but with **no vault**. The engine's `appmode set` therefore had no path to point a freshly-created config at, and fell back to the bundled demo path, which can differ from the sandbox the desktop actually seeded (`~/.prevail/demo-vault`).

## Change

- `engine_appmode_set` now takes an optional `vault` and appends `--vault` when present (mirroring the existing `engine_production_init` pattern).
- Both demo-entry call sites — `seedDemo` (first launch) and `loadSample` (Settings → load sample) — pass the path they just seeded.
- The production switch (`switchToProduction`) and `switchToDemo` paths are untouched; the new arg is optional and backward-compatible.

## Pairs with

[`prevail-cli#5`](https://github.com/fru-dev3/prevail-cli/pull/5), which fixes the actual root cause (`setAppMode` no-op'd on first launch) and consumes the forwarded `--vault` to seed `config.vaultPath` precisely. With both merged, a fresh DMG install enters demo mode with the Demo badge showing and the engine config pointed at the real sandbox.

## Verification

- `cargo check` clean · `tsc --noEmit` clean.
- Only the two demo-entry sites changed; production/switch-to-demo paths verified unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)