### PR TITLE
Finish pending hardening: pin Composio, installer integrity, read-only bridges (O17a/O37/O1)

### DIFF
--- a/src-tauri/src/discord_bridge.rs
+++ b/src-tauri/src/discord_bridge.rs
@@ -22,7 +22,7 @@ use tauri::async_runtime::JoinHandle;
 use tokio::sync::{watch, Mutex as AsyncMutex};
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 
-use crate::telegram_bridge::{record_exchange, resolve_domain, run_cli, BridgeConfig, BridgeStatus, RouteRule};
+use crate::telegram_bridge::{record_exchange, resolve_domain, run_cli_readonly, BridgeConfig, BridgeStatus, RouteRule};
 
 const GATEWAY_URL: &str = "wss://gateway.discord.gg/?v=10&encoding=json";
 const API: &str = "https://discord.com/api/v10";
@@ -155,7 +155,7 @@ async fn run_gateway(cfg: DiscordConfig, mut stop_rx: watch::Receiver<bool>, sta
                 { let mut s = status.lock().await; s.inbound_count += 1; s.last_inbound_ts = Some(now_secs()); }
                 let bcfg = bridge_cfg(&cfg);
                 let domain = cfg.domain.clone().or_else(|| resolve_domain(&bcfg, &content));
-                let reply = match run_cli(&cfg.cli, cfg.model.as_deref(), &crate::telegram_bridge::fence_untrusted_inbound(&content)).await {
+                let reply = match run_cli_readonly(&cfg.cli, cfg.model.as_deref(), &crate::telegram_bridge::fence_untrusted_inbound(&content)).await {
                     Ok(r) => r,
                     Err(e) => { status.lock().await.last_error = Some(e); continue; }
                 };

--- a/src-tauri/src/email_bridge.rs
+++ b/src-tauri/src/email_bridge.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use tauri::async_runtime::JoinHandle;
 use tokio::sync::{watch, Mutex as AsyncMutex};
 
-use crate::telegram_bridge::{record_exchange, resolve_domain, run_cli, BridgeConfig, BridgeStatus, RouteRule};
+use crate::telegram_bridge::{record_exchange, resolve_domain, run_cli_readonly, BridgeConfig, BridgeStatus, RouteRule};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EmailConfig {
@@ -125,7 +125,7 @@ impl EmailState {
                             let prompt = if inc.subject.is_empty() { inc.body.clone() } else { format!("{}\n\n{}", inc.subject, inc.body) };
                             let bcfg = bridge_cfg(&cfg);
                             let domain = cfg.domain.clone().or_else(|| resolve_domain(&bcfg, &prompt));
-                            let reply = match run_cli(&cfg.cli, cfg.model.as_deref(), &crate::telegram_bridge::fence_untrusted_inbound(&prompt)).await {
+                            let reply = match run_cli_readonly(&cfg.cli, cfg.model.as_deref(), &crate::telegram_bridge::fence_untrusted_inbound(&prompt)).await {
                                 Ok(r) => r,
                                 Err(e) => { status_task.lock().await.last_error = Some(e); continue; }
                             };

--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -929,7 +929,11 @@ pub async fn composio_cli_install(_app: tauri::AppHandle) -> Result<serde_json::
         let (_p, user, logname) = crate::build_cli_env();
         let out = Command::new("bash")
             .arg("-lc")
-            .arg("curl -fsSL https://composio.dev/install | bash")
+            // Download the installer to a temp file, then run it — don't pipe
+            // remote code straight into bash (O37). The script never bypasses
+            // disk, so it's inspectable and the download can fail cleanly.
+            // (Cryptographic SHA-pinning awaits an upstream-published checksum.)
+            .arg("set -euo pipefail; t=\"$(mktemp -t composio-install.XXXXXX)\"; curl -fsSL https://composio.dev/install -o \"$t\"; bash \"$t\"; rm -f \"$t\"")
             .env_clear()
             .envs(crate::scrubbed_env_pairs())
             .env("PATH", path)

--- a/src-tauri/src/ingestion/tier_b_composio.rs
+++ b/src-tauri/src/ingestion/tier_b_composio.rs
@@ -65,7 +65,9 @@ impl ComposioRuntime {
         };
 
         let mut cmd = Command::new("npx");
-        cmd.args(["-y", "@composio/mcp"])
+        // Pin the version (O17a) so a compromised/yanked latest can't be pulled
+        // silently. Bump deliberately when upgrading Composio.
+        cmd.args(["-y", "@composio/mcp@1.0.9"])
             .env("PATH", combined)
             .env("COMPOSIO_API_KEY", key)
             .stdin(Stdio::piped())

--- a/src-tauri/src/native_bridge.rs
+++ b/src-tauri/src/native_bridge.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 use tauri::async_runtime::JoinHandle;
 use tokio::sync::{watch, Mutex as AsyncMutex};
 
-use crate::telegram_bridge::{record_exchange, resolve_domain, run_cli, BridgeConfig, BridgeStatus, RouteRule};
+use crate::telegram_bridge::{record_exchange, resolve_domain, run_cli_readonly, BridgeConfig, BridgeStatus, RouteRule};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NativeBridgeConfig {
@@ -146,7 +146,7 @@ impl NativeBridgeState {
                                     }
                                     let bcfg = cfg.to_bridge_config();
                                     let domain = cfg.domain.clone().or_else(|| resolve_domain(&bcfg, &inc.text));
-                                    let reply = match run_cli(&cfg.cli, cfg.model.as_deref(), &crate::telegram_bridge::fence_untrusted_inbound(&inc.text)).await {
+                                    let reply = match run_cli_readonly(&cfg.cli, cfg.model.as_deref(), &crate::telegram_bridge::fence_untrusted_inbound(&inc.text)).await {
                                         Ok(r) => r,
                                         Err(e) => {
                                             let mut s = status_for_task.lock().await;

--- a/src-tauri/src/slack_bridge.rs
+++ b/src-tauri/src/slack_bridge.rs
@@ -19,7 +19,7 @@ use tauri::async_runtime::JoinHandle;
 use tokio::sync::{watch, Mutex as AsyncMutex};
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 
-use crate::telegram_bridge::{record_exchange, resolve_domain, run_cli, BridgeConfig, BridgeStatus, RouteRule};
+use crate::telegram_bridge::{record_exchange, resolve_domain, run_cli_readonly, BridgeConfig, BridgeStatus, RouteRule};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SlackConfig {
@@ -157,7 +157,7 @@ async fn run_socket(cfg: SlackConfig, mut stop_rx: watch::Receiver<bool>, status
                 { let mut s = status.lock().await; s.inbound_count += 1; s.last_inbound_ts = Some(now_secs()); }
                 let bcfg = bridge_cfg(&cfg);
                 let domain = cfg.domain.clone().or_else(|| resolve_domain(&bcfg, &text));
-                let reply = match run_cli(&cfg.cli, cfg.model.as_deref(), &crate::telegram_bridge::fence_untrusted_inbound(&text)).await {
+                let reply = match run_cli_readonly(&cfg.cli, cfg.model.as_deref(), &crate::telegram_bridge::fence_untrusted_inbound(&text)).await {
                     Ok(r) => r,
                     Err(e) => { status.lock().await.last_error = Some(e); continue; }
                 };

--- a/src-tauri/src/telegram_bridge.rs
+++ b/src-tauri/src/telegram_bridge.rs
@@ -277,7 +277,7 @@ impl BridgeState {
                                     // Dispatch to the CLI and reply. Keyword-route to a
                                     // domain first so the exchange is recorded there.
                                     let routed_domain = resolve_domain(&cfg, &text);
-                                    let cli_result = run_cli(&cfg.cli, cfg.model.as_deref(), &fence_untrusted_inbound(&text)).await;
+                                    let cli_result = run_cli_readonly(&cfg.cli, cfg.model.as_deref(), &fence_untrusted_inbound(&text)).await;
                                     typing_task.abort();
                                     match cli_result {
                                         Ok(reply) => {
@@ -699,7 +699,21 @@ pub(crate) fn fence_untrusted_inbound(content: &str) -> String {
 // processes (DoS + runaway API cost). Excess spawns queue for a permit.
 static RUN_CLI_SEM: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(4);
 
+/// Full-capability model spawn (distillation, surface, user-initiated paths).
 pub(crate) async fn run_cli(cli: &str, model: Option<&str>, prompt: &str) -> Result<String, String> {
+    run_cli_inner(cli, model, prompt, false).await
+}
+
+/// Read-only spawn for UNTRUSTED inbound (bridges): the agent may read/search to
+/// compose a reply but is denied consequential/tool actions (B3/O1). Enforced for
+/// claude via --allowedTools (read tools only, no permission bypass); ollama is
+/// inherently tool-less. Other CLIs fall back to full args but stay bounded by the
+/// untrusted-content fence + sender allowlists + the autonomy-off defaults.
+pub(crate) async fn run_cli_readonly(cli: &str, model: Option<&str>, prompt: &str) -> Result<String, String> {
+    run_cli_inner(cli, model, prompt, true).await
+}
+
+async fn run_cli_inner(cli: &str, model: Option<&str>, prompt: &str, read_only: bool) -> Result<String, String> {
     // Bound concurrency first; the permit is held for this spawn's lifetime.
     let _permit = RUN_CLI_SEM
         .acquire()
@@ -711,7 +725,13 @@ pub(crate) async fn run_cli(cli: &str, model: Option<&str>, prompt: &str) -> Res
     crate::bunker::guard_cli(cli)?;
     let (bin, args) = match cli {
         "claude" => {
-            let mut v = vec!["--dangerously-skip-permissions".to_string()];
+            // Read-only bridge profile (O1): restrict to read tools rather than
+            // bypassing every permission gate.
+            let mut v = if read_only {
+                vec!["--allowedTools".to_string(), "Read,Grep,Glob,WebSearch,WebFetch".to_string()]
+            } else {
+                vec!["--dangerously-skip-permissions".to_string()]
+            };
             if let Some(m) = model {
                 v.push("--model".into());
                 v.push(m.to_string());

--- a/src-tauri/src/webhook_bridge.rs
+++ b/src-tauri/src/webhook_bridge.rs
@@ -28,7 +28,7 @@ use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
 
-use crate::telegram_bridge::{run_cli, BridgeConfig, BridgeStatus};
+use crate::telegram_bridge::{run_cli_readonly, BridgeConfig, BridgeStatus};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WebhookConfig {
@@ -214,7 +214,7 @@ fn handle(mut req: tiny_http::Request, cfg: &WebhookConfig, status: &Arc<Mutex<B
         s.inbound_count += 1;
         s.last_inbound_ts = Some(now_secs());
     }
-    let result = tauri::async_runtime::block_on(run_cli(&cfg.cli, cfg.model.as_deref(), &crate::telegram_bridge::fence_untrusted_inbound(&hook.message)));
+    let result = tauri::async_runtime::block_on(run_cli_readonly(&cfg.cli, cfg.model.as_deref(), &crate::telegram_bridge::fence_untrusted_inbound(&hook.message)));
     match result {
         Ok(reply) => {
             if let Some(d) = domain.as_deref() {


### PR DESCRIPTION
Builds the remaining buildable deferred items from the audit:
- **O17a** pin `npx @composio/mcp@1.0.9`
- **O37** `composio_cli_install` downloads to a temp file then runs (no `curl|bash` pipe)
- **O1** read-only bridge profile: `run_cli_readonly` for all 6 bridges (claude via `--allowedTools`, ollama tool-less); distill/surface keep full capability

cargo check + 94 lib tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)