### PR TITLE
O69 DEK-off-stdout + C1 broker (desktop)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,3 +46,11 @@ aes-gcm = "0.10"
 base64 = "0.22"
 rand = "0.8"
 zeroize = "1.8" # wipe the in-memory vault DEK on lock (already in the tree via aes-gcm)
+
+# Release hardening (audit: lto/codegen-units/panic=abort) — smaller, faster, and
+# panic=abort avoids unwinding through FFI boundaries.
+[profile.release]
+lto = true
+codegen-units = 1
+panic = "abort"
+strip = true

--- a/src-tauri/src/broker.rs
+++ b/src-tauri/src/broker.rs
@@ -1,0 +1,29 @@
+// broker — the single authorization checkpoint for consequential desktop actions
+// (C1 / O94 / A-05). Instead of each consequential command verifying approval
+// inline, they call through here, so there is ONE place that answers "may this
+// action run?". Today it verifies the single-use, payload-bound approval token;
+// future policy (risk classes, budgets, rate limits) belongs here too.
+
+/// Authorize a consequential (domain, action) given its approval token. Returns
+/// Err if the token is missing / invalid / expired / replayed, or isn't bound to
+/// this exact (domain, action).
+pub(crate) fn authorize_action(domain: &str, action: &str, approval_token: &str) -> Result<(), String> {
+    if !crate::approval::verify_and_consume(approval_token, &crate::approval::action_payload(domain, action)) {
+        return Err("approval token invalid, expired, or already used".into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn authorize_requires_a_valid_bound_single_use_token() {
+        let tok = crate::approval::mint(&crate::approval::action_payload("career", "email the recruiter"));
+        // bound to the wrong action → rejected
+        assert!(super::authorize_action("career", "delete everything", &tok).is_err());
+        // correct action → accepted once
+        assert!(super::authorize_action("career", "email the recruiter", &tok).is_ok());
+        // replay → rejected (single-use)
+        assert!(super::authorize_action("career", "email the recruiter", &tok).is_err());
+    }
+}

--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -1713,14 +1713,28 @@ pub fn engine_vault_status(vault: String) -> Result<serde_json::Value, String> {
     Ok(serde_json::json!({ "encrypted": encrypted, "unlocked": vault_key().is_some() }))
 }
 
+/// Extract the DEK from a `vault unlock` response. O69: prefer the file handoff —
+/// the engine writes the DEK to a 0600 temp file and returns only its path, so the
+/// key never rides on stdout; read it, then delete the file. Falls back to an
+/// inline `key` for resilience.
+fn read_dek_from_unlock(r: &serde_json::Value) -> Result<Option<String>, String> {
+    if let Some(kf) = r.get("keyFile").and_then(|v| v.as_str()) {
+        let k = std::fs::read_to_string(kf).map_err(|e| format!("read key handoff: {e}"))?;
+        let _ = std::fs::remove_file(kf);
+        Ok(Some(k.trim().to_string()))
+    } else {
+        Ok(r.get("key").and_then(|v| v.as_str()).map(|s| s.to_string()))
+    }
+}
+
 /// Unlock the session: verify the passcode, hold the returned DEK in memory.
 /// Returns { ok } only — the key stays in Rust, never reaching JS.
 #[tauri::command]
 pub fn engine_vault_unlock(vault: String, passcode: String) -> Result<serde_json::Value, String> {
     let r = run_engine_json_stdin(&["--vault", &vault, "vault", "unlock"], &passcode)?;
     if r.get("ok").and_then(|v| v.as_bool()) == Some(true) {
-        if let Some(k) = r.get("key").and_then(|v| v.as_str()) {
-            set_vault_key(Some(k.to_string()));
+        if let Some(k) = read_dek_from_unlock(&r)? {
+            set_vault_key(Some(k));
             set_vault_root(Some(vault.clone()));
         }
         return Ok(serde_json::json!({ "ok": true }));
@@ -2376,5 +2390,21 @@ mod vault_key_state_tests {
         set_vault_root(None);
         assert_eq!(vault_key(), None);
         assert_eq!(vault_root(), None);
+    }
+
+    #[test]
+    fn unlock_dek_file_handoff_is_read_then_deleted() {
+        // O69: the engine returns the DEK via a temp file; we read it and delete it.
+        let dir = std::env::temp_dir().join(format!("prevail-dek-test-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let kf = dir.join("dek");
+        std::fs::write(&kf, "BASE64DEK==\n").unwrap();
+        let r = serde_json::json!({ "ok": true, "keyFile": kf.to_string_lossy() });
+        assert_eq!(read_dek_from_unlock(&r).unwrap().as_deref(), Some("BASE64DEK=="));
+        assert!(!kf.exists(), "handoff file is deleted after read");
+        // Resilience: fall back to an inline key when no keyFile is present.
+        let r2 = serde_json::json!({ "ok": true, "key": "INLINE==" });
+        assert_eq!(read_dek_from_unlock(&r2).unwrap().as_deref(), Some("INLINE=="));
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -39,6 +39,7 @@ pub(crate) use appcmds::secs_to_ymdhms;
 mod engine;
 mod vaultio;
 mod approval;
+mod broker;
 mod loops;
 mod activity;
 mod ingestion;

--- a/src-tauri/src/loops.rs
+++ b/src-tauri/src/loops.rs
@@ -64,9 +64,9 @@ pub(crate) async fn loop_execute_action(
     provider: Option<String>,
     model: Option<String>,
 ) -> Result<String, String> {
-    if !crate::approval::verify_and_consume(&approval, &crate::approval::action_payload(&domain, &action)) {
-        return Err("approval token invalid, expired, or already used".into());
-    }
+    // Single authorization checkpoint (C1): the broker verifies the approval token
+    // is valid, single-use, and bound to this exact (domain, action).
+    crate::broker::authorize_action(&domain, &action, &approval)?;
     tauri::async_runtime::spawn_blocking(move || {
         let mut args: Vec<String> = vec![
             "--vault".into(),


### PR DESCRIPTION
- **O69**: `engine_vault_unlock` reads the DEK from the engine's 0600 file handoff (then deletes it) instead of stdout; inline-key fallback for resilience. `read_dek_from_unlock` unit-tested.
- **C1**: `broker.rs` (`authorize_action`) — single authorization checkpoint; `loop_execute_action` routes through it.

cargo check + 96 lib tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)