### PR TITLE
ci: clippy bug-class gate + SBOM; fix flatten()-forever (Phase 5)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,22 +49,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Lint gate scoped to the BUG classes (correctness + suspicious), not style.
-  # A blanket -D warnings would false-fail on Tauri #[command] fns clippy can't
-  # see are invoked from JS; this gate catches real defects (e.g. .flatten() that
-  # loops forever on a read error) without churn.
-  clippy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: src-tauri
-      - name: Clippy (deny correctness + suspicious)
-        run: cd src-tauri && cargo clippy --all-targets -- -D clippy::correctness -D clippy::suspicious
+  # NOTE: the clippy bug-class gate (deny correctness + suspicious) runs in the
+  # macos-14 `rust` job in test.yml, which already builds the sidecar + native
+  # webview. Running clippy on ubuntu here would need the full GTK/glib apt
+  # toolchain just to satisfy the build, so it lives with the existing macOS
+  # rust job instead of being duplicated.
 
   # Software Bill of Materials: a CycloneDX SBOM of the Rust dependency tree,
   # published as a build artifact for supply-chain auditing (O92 sibling).

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,3 +48,38 @@ jobs:
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Lint gate scoped to the BUG classes (correctness + suspicious), not style.
+  # A blanket -D warnings would false-fail on Tauri #[command] fns clippy can't
+  # see are invoked from JS; this gate catches real defects (e.g. .flatten() that
+  # loops forever on a read error) without churn.
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: src-tauri
+      - name: Clippy (deny correctness + suspicious)
+        run: cd src-tauri && cargo clippy --all-targets -- -D clippy::correctness -D clippy::suspicious
+
+  # Software Bill of Materials: a CycloneDX SBOM of the Rust dependency tree,
+  # published as a build artifact for supply-chain auditing (O92 sibling).
+  sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-cyclonedx
+        run: cargo install cargo-cyclonedx --locked
+      - name: Generate CycloneDX SBOM
+        run: cd src-tauri && cargo cyclonedx --format json
+      - name: Upload SBOM
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sbom-cyclonedx
+          path: src-tauri/**/*.cdx.json
+          if-no-files-found: warn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,10 @@ jobs:
       - name: Test
         working-directory: src-tauri
         run: cargo test
-      - name: Clippy
+      - name: Clippy (deny bug classes)
         working-directory: src-tauri
-        # Not -D warnings yet (pre-existing lint debt); tighten after a cleanup pass.
-        run: cargo clippy
+        # Deny the BUG classes (correctness + suspicious) — these catch real
+        # defects like .flatten() that loops forever on a read error. NOT
+        # -D warnings: that would false-fail on Tauri #[command] fns clippy
+        # can't see are invoked from JS, plus pre-existing style lint debt.
+        run: cargo clippy --all-targets -- -D clippy::correctness -D clippy::suspicious

--- a/src-tauri/src/ingestion/tier_c_browser.rs
+++ b/src-tauri/src/ingestion/tier_c_browser.rs
@@ -125,7 +125,9 @@ impl BrowserRunner {
             std::thread::spawn(move || {
                 use tauri::Emitter;
                 let reader = BufReader::new(out);
-                for line in reader.lines().flatten() {
+                // map_while(Result::ok) stops on the first read error; .flatten()
+                // would spin forever if the stream keeps yielding Err.
+                for line in reader.lines().map_while(Result::ok) {
                     // Re-emit verbatim; UI parses the shape.
                     let _ = app2.emit(
                         "ingestion:browser",
@@ -194,7 +196,7 @@ impl BrowserRunner {
             std::thread::spawn(move || {
                 use tauri::Emitter;
                 let reader = BufReader::new(err);
-                for line in reader.lines().flatten() {
+                for line in reader.lines().map_while(Result::ok) {
                     let _ = app3.emit(
                         "ingestion:browser",
                         serde_json::json!({


### PR DESCRIPTION
Adds a clippy CI gate scoped to correctness+suspicious (not -D warnings, which would false-fail on JS-invoked Tauri commands), a CycloneDX SBOM artifact job, and fixes the 2 real `flatten()`-loops-forever defects the suspicious class flagged (→ `map_while(Result::ok)`). cargo check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)