### PR TITLE
fix(chat): council / + $ hints; / skills empty-state

### DIFF
--- a/src/chatpanel.tsx
+++ b/src/chatpanel.tsx
@@ -1923,13 +1923,16 @@ export function ChatPanel({
               <button onClick={() => setAttachErr(null)} className="shrink-0 text-warn/70 hover:text-warn">×</button>
             </div>
           )}
-          {/* Slash-command popover for skills */}
-          {slashMatch && slashCandidates.length > 0 && (
+          {/* Slash-command popover for skills. Shown whenever a `/` is typed —
+              including an empty state — so it never looks broken. */}
+          {slashMatch && (
             <div className="absolute bottom-full left-3 z-40 mb-1 w-80 overflow-hidden rounded-lg border border-border bg-surface shadow-xl">
               <div className="border-b border-border-subtle bg-surface-warm px-3 py-1.5 font-mono text-[10px] uppercase tracking-wider text-text-muted">
                 Skills · enter to insert
               </div>
-              {slashCandidates.map((s, i) => (
+              {slashCandidates.length === 0 ? (
+                <div className="px-3 py-2 text-[11px] text-text-muted">No skills in this vault yet — add one in a domain's <span className="font-mono">_skills/</span> folder.</div>
+              ) : slashCandidates.map((s, i) => (
                 <button
                   key={s.path}
                   onMouseDown={(e) => { e.preventDefault(); applySlashCompletion(s.name); }}

--- a/src/councilpanel.tsx
+++ b/src/councilpanel.tsx
@@ -1190,11 +1190,14 @@ export function CouncilPanel({
             <Ghost className="h-3 w-3" /> Incognito
           </span>
         )}
-        {/* Slash-command popover for skills (parity with Chat) */}
-        {slashMatch && slashCandidates.length > 0 && (
+        {/* Slash-command popover for skills (parity with Chat). Shown whenever a
+            `/` is typed — including an empty state — so it never looks broken. */}
+        {slashMatch && (
           <div className="absolute bottom-full left-3 z-40 mb-1 w-80 overflow-hidden rounded-lg border border-border bg-surface shadow-xl">
             <div className="border-b border-border-subtle bg-surface-warm px-3 py-1.5 font-mono text-[10px] uppercase tracking-wider text-text-muted">Skills · enter to insert</div>
-            {slashCandidates.map((s, i) => (
+            {slashCandidates.length === 0 ? (
+              <div className="px-3 py-2 text-[11px] text-text-muted">No skills in this vault yet — add one in a domain's <span className="font-mono">_skills/</span> folder.</div>
+            ) : slashCandidates.map((s, i) => (
               <button key={s.path} onMouseDown={(e) => { e.preventDefault(); applySlashCompletion(s.name); }}
                 className={`flex w-full items-start gap-2 px-3 py-1.5 text-left ${i === slashIdx ? "bg-accent-soft" : "hover:bg-surface-warm"}`}>
                 <Sparkles className="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-muted" />
@@ -1330,7 +1333,7 @@ export function CouncilPanel({
                 convene();
               }
             }}
-            placeholder="ask the council · enter to convene · shift+enter for newline"
+            placeholder="ask the council · enter to convene · / skills · $ context · shift+enter for newline"
             rows={2}
             disabled={phase === "panelists" || phase === "synthesizing"}
             className="w-full resize-none bg-transparent px-2 py-1.5 text-sm text-text-primary placeholder:text-text-muted focus:outline-none disabled:opacity-50"


### PR DESCRIPTION
- Council composer now advertises `/ skills` and `$ context` (popovers already existed, weren't hinted).
- `/` skills popover was hidden when a vault has no skills, so it looked broken vs `$`. Now it opens on any `/` with an empty-state telling you how to add skills (Chat + Council).

Note: your active `vault-1-demo` has no `_skills/` dirs, which is why `/` showed nothing — the bundled sample vault does have skills. tsc + build + tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)